### PR TITLE
Disable pre-commit mypy

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,12 +13,13 @@ repos:
     hooks:
       - id: black
         language_version: python3
-        args: [--line-length=100]
-  - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.4.1
-    hooks:
-      - id: mypy
-        additional_dependencies: [pydantic]
+        args:
+          [--line-length=100]
+          # - repo: https://github.com/pre-commit/mirrors-mypy
+          #   rev: v1.4.1
+          #   hooks:
+          #     - id: mypy
+          #       additional_dependencies: [pydantic]
   - repo: https://github.com/charliermarsh/ruff-pre-commit
     rev: v0.0.275
     hooks:


### PR DESCRIPTION
`pre-commit` is unhappy with the backend being in a subdirectory and mypy is not finding the pydantic plugin because of this causing errors when there shouldn't be any. I'm disabling mypy in pre-commit for now while I look for a solution to this. Mypy can still be run locally with `just mypy` or `just lint`. Mypy is still run in CI also so errors will still be caught.