### PR TITLE
Bump pre-commit dependencies

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,7 +9,7 @@ repos:
       - id: end-of-file-fixer
       - id: trailing-whitespace
   - repo: https://github.com/psf/black
-    rev: 23.3.0
+    rev: 23.7.0
     hooks:
       - id: black
         language_version: python3
@@ -21,12 +21,12 @@ repos:
           #     - id: mypy
           #       additional_dependencies: [pydantic]
   - repo: https://github.com/charliermarsh/ruff-pre-commit
-    rev: v0.0.275
+    rev: v0.0.277
     hooks:
       - id: ruff
         args: [--fix, --exit-non-zero-on-fix]
   - repo: https://github.com/pre-commit/mirrors-prettier
-    rev: v3.0.0-alpha.9-for-vscode
+    rev: v3.0.0
     hooks:
       - id: prettier
         additional_dependencies:


### PR DESCRIPTION
[https://github.com/psf/black] updating 23.3.0 -> 23.7.0
[https://github.com/charliermarsh/ruff-pre-commit] updating v0.0.275 -> v0.0.277
[https://github.com/pre-commit/mirrors-prettier] updating v3.0.0-alpha.9-for-vscode -> v3.0.0